### PR TITLE
feat: add workspace save/restore scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ litellm_uuid.txt
 file.txt
 numbers.txt
 poetry.lock
+
+# Workspace states
+.workspace_states/

--- a/scripts/restore_workspace.sh
+++ b/scripts/restore_workspace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# 保存当前分支名
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# 检查是否存在保存的状态
+if [ -d ".workspace_states/$current_branch" ]; then
+    # 恢复IDE配置文件
+    cp -r .workspace_states/$current_branch/.vscode . 2>/dev/null || true
+    cp -r .workspace_states/$current_branch/.cursor . 2>/dev/null || true
+    echo "Workspace state restored for branch: $current_branch"
+else
+    echo "No saved workspace state found for branch: $current_branch"
+fi 

--- a/scripts/save_workspace.sh
+++ b/scripts/save_workspace.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# 保存当前分支名
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+
+# 创建工作区状态目录
+mkdir -p .workspace_states/$current_branch
+
+# 复制IDE配置文件
+cp -r .vscode .workspace_states/$current_branch/ 2>/dev/null || true
+cp -r .cursor .workspace_states/$current_branch/ 2>/dev/null || true
+
+echo "Workspace state saved for branch: $current_branch" 


### PR DESCRIPTION
Add scripts to save and restore workspace state for development. Also update gitignore to handle workspace state files.

### Describe the changes you have made:

### Reference any relevant issues (e.g. "Fixes #000"):

### Pre-Submission Checklist (optional but appreciated):

- [ ] I have included relevant documentation updates (stored in /docs)
- [ ] I have read `docs/CONTRIBUTING.md`
- [ ] I have read `docs/ROADMAP.md`

### OS Tests (optional but appreciated):

- [ ] Tested on Windows
- [ ] Tested on MacOS
- [ ] Tested on Linux

## Summary by Sourcery

Add scripts to save and restore workspace states. Update .gitignore to exclude workspace state files.

New Features:
- Introduce save/restore scripts to manage workspace state for different git branches

Chores:
- .gitignore updated to ignore workspace state files