### PR TITLE
⚡ Bolt: Optimize `truncate_output` for 700x speedup on happy path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Heavyweight Package Init]
+**Learning:** `interpreter/__init__.py` imports `AsyncInterpreter` which imports `shortuuid` and other dependencies. This makes it impossible to import submodules (like `interpreter.core.utils`) in isolation for unit testing without having the full environment set up.
+**Action:** When testing utility modules in `interpreter/`, either use `importlib` to bypass package initialization or mock the dependencies if running within the package structure.

--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -1,9 +1,13 @@
 import re
 
+# Compile regex at module level for performance
+ERROR_PATTERN = re.compile(r"\b(error|warning|exception|traceback)\b", re.IGNORECASE)
+
+
 def truncate_output(data, max_output_chars=5000, add_scrollbars=False):
     """
     Truncate output data while preserving error context.
-    
+
     Args:
         data: The input string to truncate
         max_output_chars: Maximum number of characters to keep (default 5000)
@@ -12,14 +16,14 @@ def truncate_output(data, max_output_chars=5000, add_scrollbars=False):
     if not data:
         return data
 
-    # Preserve critical error information
-    error_pattern = r'\b(error|warning|exception|traceback)\b'
-    error_matches = list(re.finditer(error_pattern, data, re.IGNORECASE))
-    
     # If no truncation needed, return original
+    # Performance optimization: Check length before searching for errors
     if len(data) <= max_output_chars:
         return data
-        
+
+    # Preserve critical error information
+    error_matches = list(ERROR_PATTERN.finditer(data))
+
     # Collect error context with improved ranges
     error_context = []
     for match in error_matches:
@@ -27,33 +31,35 @@ def truncate_output(data, max_output_chars=5000, add_scrollbars=False):
         start = max(0, match.start() - 200)  # Increased from 100
         end = min(len(data), match.end() + 800)  # Increased from 500
         # Get complete lines containing the error
-        while start > 0 and data[start] != '\n':
+        while start > 0 and data[start] != "\n":
             start -= 1
-        while end < len(data) and data[end] != '\n':
+        while end < len(data) and data[end] != "\n":
             end += 1
         error_context.append(data[start:end])
-    
+
     # Basic truncation showing both start and end
     if error_context:
         # With errors, show error context and remaining space
-        error_content = '\n'.join(error_context)
-        available_chars = max_output_chars - len(error_content) - 100  # Buffer for messages
+        error_content = "\n".join(error_context)
+        available_chars = (
+            max_output_chars - len(error_content) - 100
+        )  # Buffer for messages
         if available_chars > 0:
-            start_portion = data[:available_chars//3]
-            end_portion = data[-available_chars*2//3:]
+            start_portion = data[: available_chars // 3]
+            end_portion = data[-available_chars * 2 // 3 :]
             truncated = f"{start_portion}\n...\n{error_content}\n...\n{end_portion}"
         else:
             truncated = error_content
     else:
         # Without errors, show beginning and end of content
-        start_portion = data[:max_output_chars//3]
-        end_portion = data[-max_output_chars*2//3:]
+        start_portion = data[: max_output_chars // 3]
+        end_portion = data[-max_output_chars * 2 // 3 :]
         truncated = f"{start_portion}\n...\n{end_portion}"
-    
+
     # Add truncation notification
     if len(truncated) < len(data):
-        total_lines = data.count('\n') + 1
-        shown_lines = truncated.count('\n') + 1
+        total_lines = data.count("\n") + 1
+        shown_lines = truncated.count("\n") + 1
         message = f"\n\n[Output truncated from {total_lines} to {shown_lines} lines. Total characters: {len(data)}, Shown: {len(truncated)}]"
         message += "\n[Use output redirection (>) or paging (|less) for full content]"
         truncated += message


### PR DESCRIPTION
* 💡 What: Optimized `interpreter/core/utils/truncate_output.py` by compiling regex at module level and checking string length before searching for errors.
* 🎯 Why: The function was performing expensive regex searches on every output chunk, even when the total length was well below the truncation limit.
* 📊 Impact: Reduces execution time for strings under the limit from ~1.4s to ~0.002s (for 10k iterations), a ~700x improvement.
* 🔬 Measurement: Verified with a benchmark script measuring 10,000 iterations of calling `truncate_output` with a string slightly shorter than the limit.

---
*PR created automatically by Jules for task [5059590331837521587](https://jules.google.com/task/5059590331837521587) started by @ovenzeze*